### PR TITLE
Fix API profile endpoint

### DIFF
--- a/src/model/account/profile.rs
+++ b/src/model/account/profile.rs
@@ -9,7 +9,7 @@ impl GetRequest {
     pub fn new() -> Self {
         Self {
             method: http::Method::GET,
-            path: "/api/account/profile".to_string(),
+            path: "/api/account".to_string(),
             query: Default::default(),
             body: Default::default(),
         }


### PR DESCRIPTION
The endpoint is `/api/account`, as specified here: https://lichess.org/api#tag/Account/operation/accountMe