### PR TITLE
Fix status parameter name in GameJson

### DIFF
--- a/src/model/games/mod.rs
+++ b/src/model/games/mod.rs
@@ -33,7 +33,7 @@ pub struct GameJson {
     perf: String,
     created_at: u64,
     last_move_at: Option<u64>,
-    status_name: GameStatus,
+    status: GameStatus,
     players: Players,
     opening: Option<Opening>,
     moves: String,


### PR DESCRIPTION
A "status" field is returned, not "status_name".

Cf. https://lichess.org/api#tag/Challenges/operation/challengeAi