### PR TITLE
Make fields optional in GameEventPlayer

### DIFF
--- a/src/model/board/stream/game.rs
+++ b/src/model/board/stream/game.rs
@@ -97,10 +97,10 @@ pub struct OpponentGone {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GameEventPlayer {
-    pub id: String,
+    pub id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ai_level: Option<u32>,
-    pub name: String,
+    pub name: Option<String>,
     // This field can be null according to the openapi spec.
     pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
When describing a bot, everything is empty except the AI level field.